### PR TITLE
fix lua error caused by api changes in 11.0.2

### DIFF
--- a/ForTheHorde.lua
+++ b/ForTheHorde.lua
@@ -22,6 +22,7 @@ local triggers = {
   { trigger = C_Spell.GetSpellName(309658), spellId = 309658, var_name = 'drums_of_deathly_ferocity',  opt_name = "DrumsOfDeathlyFerocity",  gv = 'FTH_DDM', default = 1 },
   { trigger = C_Spell.GetSpellName(390386), spellId = 390386, var_name = 'fury_of_the_aspects',        opt_name = "FuryOfTheAspects",        gv = 'FTH_FOA', default = 1 },
   { trigger = C_Spell.GetSpellName(264667), spellId = 264667, var_name = "primal_rage",                opt_name = "PrimalRage",              gv = 'FTH_PR',  default = 1 },
+  { trigger = C_Spell.GetSpellName(383243), spellId = 342242, var_name = "time_anomaly",               opt_name = "TimeAnomaly",             gv = 'FTH_TA',  default = 1 },
 };
 
 -- Main Options Window
@@ -58,7 +59,6 @@ end
 
 -- Register events that we listen for
 ForTheHorde.gvif:RegisterEvent("ADDON_LOADED");
-ForTheHorde.gvif:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
 ForTheHorde.gvif:RegisterEvent("PLAYER_ENTERING_WORLD");
 ForTheHorde.gvif:RegisterEvent("PLAYER_LOGOUT");
 ForTheHorde.gvif:RegisterEvent("UNIT_AURA");
@@ -76,10 +76,7 @@ function ForTheHorde.gvif:OnEvent( event, arg1, arg2, arg3, arg4, arg5, arg6, ar
                 auraData = C_UnitAuras.GetBuffDataByIndex("player",i);
 		if auraData ~= nil then
                   if ( auraData["spellId"] == trigger_table["spellId"] and auraData["duration"] - (auraData["expirationTime"] - GetTime()) < 1 ) then
-	            -- Check for Time Anomaly (8 second trigger)
-		    if ForTheHorde["sound_on_time_anomaly"] == 1 or auraData["duration"] > 6 or addedAura["name"] ~= C_Spell.GetSpellName(80353) then
                       doTrigger = true;
-		    end
                     break 
                   end
                 end
@@ -108,12 +105,6 @@ function ForTheHorde.gvif:OnEvent( event, arg1, arg2, arg3, arg4, arg5, arg6, ar
           ForTheHorde['sound_on_' .. trigger_table["var_name"]] = trigger_table["default"];
         end
       end
-      -- Time Anomaly
-      if _G["FTH_TA"] ~= nil then
-        ForTheHorde['sound_on_time_anomaly'] = _G["FTH_TA"]
-      else
-	ForTheHorde['sound_on_time_anomaly'] = 0
-      end
 
       Settings.RegisterAddOnCategory(Settings.RegisterCanvasLayoutCategory(ForTheHorde.gvif, "For The Horde"));
 
@@ -124,13 +115,7 @@ function ForTheHorde.gvif:OnEvent( event, arg1, arg2, arg3, arg4, arg5, arg6, ar
         y = y - 30;
       end
       
-      -- Time Anomaly (Mage Talent)
-      local taCheckBox = createOptions(C_Spell.GetSpellName(383243), "TimeAnomaly", "sound_on_time_anomaly", 10, y);
-      if ForTheHorde["sound_on_time_anomaly"] == 1 then
-        taCheckBox:SetChecked(true)
-      end
 
-      y = y - 30;
       y = y - 60;
       -- Sound override
       local chkbox_override = CreateFrame( "CheckButton","Override_CheckBox_GlobalName", ForTheHorde.gvif, "InterfaceOptionsCheckButtonTemplate" );
@@ -155,7 +140,6 @@ function ForTheHorde.gvif:OnEvent( event, arg1, arg2, arg3, arg4, arg5, arg6, ar
     for _,trigger_table in ipairs(triggers) do
       _G[trigger_table["gv"]] = ForTheHorde['sound_on_' .. trigger_table["var_name"]];
     end
-    _G["FTH_TA"] = ForTheHorde["sound_on_time_anomaly"]
   end
 end
 ForTheHorde.gvif:SetScript("OnEvent",ForTheHorde.gvif.OnEvent);

--- a/ForTheHorde.lua
+++ b/ForTheHorde.lua
@@ -10,17 +10,18 @@ local gvif_opts,current_opts;
 -- Triggers
 
 local triggers = {
-  { trigger = GetSpellInfo(90355),  var_name = 'ancient_hysteria',           opt_name = "AncientHysteria",         gv = 'FTH_AH',  default = 1 },
-  { trigger = GetSpellInfo(2825),   var_name = 'bloodlust',                  opt_name = "Bloodlust",               gv = 'FTH_BL',  default = 1 },
-  { trigger = GetSpellInfo(178207), var_name = 'drums_of_fury',              opt_name = "DrumsOfFury",             gv = 'FTH_DOF', default = 1 },
-  { trigger = GetSpellInfo(230935), var_name = 'drums_of_the_mountain',      opt_name = "DrumsOfTheMountain",      gv = 'FTH_DOM', default = 1 },
-  { trigger = GetSpellInfo(32182),  var_name = 'heroism',                    opt_name = "Heroism",                 gv = 'FTH_H',   default = 1 },
-  { trigger = GetSpellInfo(160452), var_name = 'netherwinds',                opt_name = "Netherwinds",             gv = 'FTH_NW',  default = 1 },
-  { trigger = GetSpellInfo(80353),  var_name = 'time_warp',                  opt_name = "TimeWarp",                gv = 'FTH_TW',  default = 1 },
-  { trigger = GetSpellInfo(292686), var_name = 'mallet_of_thunderous_skins', opt_name = "MalletOfThunderousSkins", gv = 'FTH_MTS', default = 1 },
-  { trigger = GetSpellInfo(256740), var_name = 'drums_of_the_maelstrom',     opt_name = "DrumsOfTheMaelstrom",     gv = 'FTH_DM',  default = 1 },
-  { trigger = GetSpellInfo(309658), var_name = 'drums_of_deathly_ferocity',  opt_name = "DrumsOfDeathlyFerocity",  gv = 'FTH_DDM', default = 1 },
-  { trigger = GetSpellInfo(390386), var_name = 'fury_of_the_aspects',        opt_name = "FuryOfTheAspects",        gv = 'FTH_FOA', default = 1 },
+  { trigger = C_Spell.GetSpellName(90355),  spellId = 90335,  var_name = 'ancient_hysteria',           opt_name = "AncientHysteria",         gv = 'FTH_AH',  default = 1 },
+  { trigger = C_Spell.GetSpellName(2825),   spellId = 2825,   var_name = 'bloodlust',                  opt_name = "Bloodlust",               gv = 'FTH_BL',  default = 1 },
+  { trigger = C_Spell.GetSpellName(178207), spellId = 178207, var_name = 'drums_of_fury',              opt_name = "DrumsOfFury",             gv = 'FTH_DOF', default = 1 },
+  { trigger = C_Spell.GetSpellName(230935), spellId = 230935, var_name = 'drums_of_the_mountain',      opt_name = "DrumsOfTheMountain",      gv = 'FTH_DOM', default = 1 },
+  { trigger = C_Spell.GetSpellName(32182),  spellId = 32182,  var_name = 'heroism',                    opt_name = "Heroism",                 gv = 'FTH_H',   default = 1 },
+  { trigger = C_Spell.GetSpellName(160452), spellId = 160452, var_name = 'netherwinds',                opt_name = "Netherwinds",             gv = 'FTH_NW',  default = 1 },
+  { trigger = C_Spell.GetSpellName(80353),  spellId = 80353,  var_name = 'time_warp',                  opt_name = "TimeWarp",                gv = 'FTH_TW',  default = 1 },
+  { trigger = C_Spell.GetSpellName(292686), spellId = 292686, var_name = 'mallet_of_thunderous_skins', opt_name = "MalletOfThunderousSkins", gv = 'FTH_MTS', default = 1 },
+  { trigger = C_Spell.GetSpellName(256740), spellId = 256740, var_name = 'drums_of_the_maelstrom',     opt_name = "DrumsOfTheMaelstrom",     gv = 'FTH_DM',  default = 1 },
+  { trigger = C_Spell.GetSpellName(309658), spellId = 309658, var_name = 'drums_of_deathly_ferocity',  opt_name = "DrumsOfDeathlyFerocity",  gv = 'FTH_DDM', default = 1 },
+  { trigger = C_Spell.GetSpellName(390386), spellId = 390386, var_name = 'fury_of_the_aspects',        opt_name = "FuryOfTheAspects",        gv = 'FTH_FOA', default = 1 },
+  { trigger = C_Spell.GetSpellName(264667), spellId = 264667, var_name = "primal_rage",                opt_name = "PrimalRage",              gv = 'FTH_PR',  default = 1 },
 };
 
 -- Main Options Window
@@ -69,13 +70,16 @@ function ForTheHorde.gvif:OnEvent( event, arg1, arg2, arg3, arg4, arg5, arg6, ar
       if addedAuras ~= nil then
         for _,addedAura in ipairs(addedAuras) do
           for _,trigger_table in ipairs(triggers) do
-            if ( addedAura["name"] == trigger_table["trigger"] and ForTheHorde['sound_on_' .. trigger_table["var_name"]] == 1 ) then
+            if ( addedAura["spellId"] == trigger_table["spellId"] and ForTheHorde['sound_on_' .. trigger_table["var_name"]] == 1 ) then
               local auraData, i, doTrigger = nil, 1, false;
               repeat 
                 auraData = C_UnitAuras.GetBuffDataByIndex("player",i);
 		if auraData ~= nil then
-                  if ( auraData["name"] == trigger_table["trigger"] and auraData["duration"] - (auraData["expirationTime"] - GetTime()) < 1 ) then
-                    doTrigger = true;
+                  if ( auraData["spellId"] == trigger_table["spellId"] and auraData["duration"] - (auraData["expirationTime"] - GetTime()) < 1 ) then
+	            -- Check for Time Anomaly (8 second trigger)
+		    if ForTheHorde["sound_on_time_anomaly"] == 1 or auraData["duration"] > 6 or addedAura["name"] ~= C_Spell.GetSpellName(80353) then
+                      doTrigger = true;
+		    end
                     break 
                   end
                 end
@@ -104,6 +108,13 @@ function ForTheHorde.gvif:OnEvent( event, arg1, arg2, arg3, arg4, arg5, arg6, ar
           ForTheHorde['sound_on_' .. trigger_table["var_name"]] = trigger_table["default"];
         end
       end
+      -- Time Anomaly
+      if _G["FTH_TA"] ~= nil then
+        ForTheHorde['sound_on_time_anomaly'] = _G["FTH_TA"]
+      else
+	ForTheHorde['sound_on_time_anomaly'] = 0
+      end
+
       Settings.RegisterAddOnCategory(Settings.RegisterCanvasLayoutCategory(ForTheHorde.gvif, "For The Horde"));
 
       --InterfaceOptions_AddCategory(ForTheHorde.gvif);
@@ -112,6 +123,14 @@ function ForTheHorde.gvif:OnEvent( event, arg1, arg2, arg3, arg4, arg5, arg6, ar
         createOptions( trigger_table["trigger"], trigger_table["opt_name"], "sound_on_" .. trigger_table["var_name"], 10, y );
         y = y - 30;
       end
+      
+      -- Time Anomaly (Mage Talent)
+      local taCheckBox = createOptions(C_Spell.GetSpellName(383243), "TimeAnomaly", "sound_on_time_anomaly", 10, y);
+      if ForTheHorde["sound_on_time_anomaly"] == 1 then
+        taCheckBox:SetChecked(true)
+      end
+
+      y = y - 30;
       y = y - 60;
       -- Sound override
       local chkbox_override = CreateFrame( "CheckButton","Override_CheckBox_GlobalName", ForTheHorde.gvif, "InterfaceOptionsCheckButtonTemplate" );
@@ -136,6 +155,7 @@ function ForTheHorde.gvif:OnEvent( event, arg1, arg2, arg3, arg4, arg5, arg6, ar
     for _,trigger_table in ipairs(triggers) do
       _G[trigger_table["gv"]] = ForTheHorde['sound_on_' .. trigger_table["var_name"]];
     end
+    _G["FTH_TA"] = ForTheHorde["sound_on_time_anomaly"]
   end
 end
 ForTheHorde.gvif:SetScript("OnEvent",ForTheHorde.gvif.OnEvent);


### PR DESCRIPTION
trigger is now using C_Spell.GetSpellName instead of GetSpellInfo, which is deprecated in 11.0.2. this would fix the lua error introduced in 11.0.2.
Also adding spellId and checking auras' spellId to trigger sound instead of auras' name, this could make checking time anomaly more easy cuz its spellId differs from time wrap.
features are fully tested and work fine.